### PR TITLE
Swallow errors when attempting to mutate API responses

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -133,7 +133,12 @@ export default function(config = {}, getCookiesFor = defaultGetCookiesFor(), get
           api.mutate(
             function(response, config) {
               if (typeof response.map !== 'function') {
-                return deepAssign(response, value)
+                try {
+                  return deepAssign(response, value)
+                } catch(e) {
+                  // unable to merge the objects
+                  return response;
+                }
               }
               return response.map((item, i, arr) => {
                 let res = value;


### PR DESCRIPTION
When attempting to merge an array into a API response object an error is
thrown, swallow the error siliently.